### PR TITLE
adding base abilities to parser

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,7 +224,7 @@ roots = []
 
 def repl_function(ref):
     if any(math_sym in ref.group(1) for math_sym in MATH_SYMBOLS):
-        return ref.group(1)
+        return '(' + ref.group(1) + ')'
 
     res = get_value_by_path(roots, ref.group(1))
 


### PR DESCRIPTION
* added to repl_function since several abilities (e.g. Malf/Regrowth, Stukov/Healing Pathogen, Rexxar/Mend Pet) have nested tags (like [d ref=]) that do math
* currently throws warnings for `unknown end tag: w` and `unknown startend tag: li {}`; not sure if you want to handle those explicitly or leave them alone (since they are empty tags)